### PR TITLE
Cache calls to `cudaFuncGetAttributes` and `cudaDeviceGetAttribute` within `cub::PtxVersion` and `cub::SmVersion`

### DIFF
--- a/cub/util_arch.cuh
+++ b/cub/util_arch.cuh
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -12,7 +12,7 @@
  *     * Neither the name of the NVIDIA CORPORATION nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -57,6 +57,15 @@ namespace cub {
     #endif
 #endif
 
+
+/// Maximum number of devices supported.
+#ifndef CUB_MAX_DEVICES
+    #define CUB_MAX_DEVICES 128
+#endif
+
+#if __cplusplus >= 201103L
+    static_assert(CUB_MAX_DEVICES > 0, "CUB_MAX_DEVICES must be greater than 0.");
+#endif
 
 /// Whether or not the source targeted by the active compiler pass is allowed to  invoke device kernels or methods from the CUDA runtime API.
 #ifndef CUB_RUNTIME_FUNCTION


### PR DESCRIPTION
Cache calls to `cudaFuncGetAttributes` and `cudaDeviceGetAttribute` within `cub::PtxVersion` and `cub::SmVersion`. These CUDA APIs acquire locks to CUDA driver/runtime mutex and perform
poorly under contention.

Caching is only done in C++11 as we need a guarantee of thread-safe initialization of statics. Caching is multi-device aware; a `cub::SwitchDevice` RAII class and `cub::CurrentDevice` function have been added to facilitate this.