### PR TITLE
Fix a bad signed/unsigned comparison in the WarpReduce `__shfl_sync` specialization

### DIFF
--- a/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -96,13 +96,13 @@ struct WarpReduceShfl
     //---------------------------------------------------------------------
 
     /// Lane index in logical warp
-    unsigned int lane_id;
+    int lane_id;
 
     /// Logical warp index in 32-thread physical warp
-    unsigned int warp_id;
+    int warp_id;
 
     /// 32-thread physical warp member mask of logical warp
-    unsigned int member_mask;
+    int member_mask;
 
 
     //---------------------------------------------------------------------


### PR DESCRIPTION
Bug 2796705

[Internal CI job](http://ausdvs.nvidia.com/Build_Results?virtualId=1000575179&which_page=current_build)