### PR TITLE
Use placement new to construct item on uninitialized memory.

### DIFF
--- a/cub/block/block_exchange.cuh
+++ b/cub/block/block_exchange.cuh
@@ -472,7 +472,7 @@ private:
         {
             int item_offset = warp_offset + (ITEM * WARP_TIME_SLICED_THREADS) + lane_id;
             if (INSERT_PADDING) item_offset += item_offset >> LOG_SMEM_BANKS;
-            temp_storage.buff[item_offset] = input_items[ITEM];
+            new (&temp_storage.buff[item_offset]) InputT (input_items[ITEM]);
         }
 
         WARP_SYNC(0xffffffff);


### PR DESCRIPTION
Formerly used the assignment operator to copy to uninitialized
memory. But a non-trivial assignment operator requires the destination
object be in a valid state. So use placement new to construct the item
on the uninitialized bits.

Partial fix for thrust issue 1153
Also a similar fix in thrust.