### PR TITLE
Qualify namespace for va_printf

### DIFF
--- a/cub/util_debug.cuh
+++ b/cub/util_debug.cuh
@@ -146,9 +146,9 @@ __host__ __device__ __forceinline__ cudaError_t Debug(
         #endif
             }
         #ifndef __CUDA_ARCH__
-            #define _CubLog(format, ...) va_printf(format,__VA_ARGS__);
+            #define _CubLog(format, ...) cub::va_printf(format,__VA_ARGS__);
         #else
-            #define _CubLog(format, ...) va_printf("[block (%d,%d,%d), thread (%d,%d,%d)]: " format, __VA_ARGS__);
+            #define _CubLog(format, ...) cub::va_printf("[block (%d,%d,%d), thread (%d,%d,%d)]: " format, __VA_ARGS__);
         #endif
     #endif
 #endif


### PR DESCRIPTION
`va_printf` function  defined here is in `cub` namespace unlike global `printf`. When Thrust uses _CubLog macro https://github.com/thrust/thrust/blob/372dea514e774ac91e2a34ef766c07eaace3027b/thrust/system/cuda/detail/core/agent_launcher.h#L562 ,  it does it  outside `cub` namespace and Thrust compilation with clang cuda compiler fails. Qualifying namespace here solves the issue.