### PR TITLE
Add a #pragma unroll to block_radix_rank.

### DIFF
--- a/cub/block/block_radix_rank.cuh
+++ b/cub/block/block_radix_rank.cuh
@@ -395,6 +395,7 @@ public:
         CTA_SYNC();
 
         // Extract the local ranks of each key
+        #pragma unroll
         for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM)
         {
             // Add in thread block exclusive prefix


### PR DESCRIPTION
Speeds up clang sorts with 32-bit keys by a factor of 1.5-2x.  No change to 64-bit keys, and no change with nvcc.